### PR TITLE
Check for overrides when --device is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Fixed
-- check-smart-status.rb: Check for overrides when --device is used (#110)
+- check-smart-status.rb: Check for overrides when --device is used (@GwennG)
 
 ### Breaking Changes
 - check-smart.rb: fixing a `undefined` error by renaming `no-smart-capable-disks` to `--zero-smart-capable_disks` as the parser sees any `--no-` argument and attempts to negate it which a `(True|False)Class` can not be cast to a symbol (@bdeluca)

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -272,7 +272,16 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     # Return parameter value if it's defined
     if config[:devices] != 'all'
       config[:devices].split(',').each do |dev|
-        devices << Disk.new(dev.to_s, '', nil)
+        jconfig = @hardware.find { |h1| h1[:path] == dev }
+
+        if jconfig.nil?
+          override = nil
+          ignore = nil
+        else
+          override = jconfig[:override]
+          ignore = jconfig[:ignore]
+        end
+        devices << Disk.new(dev.to_s, override, ignore)
       end
       return devices
     end


### PR DESCRIPTION
Fix for https://github.com/sensu-plugins/sensu-plugins-disk-checks/issues/110

## Pull Request Checklist

#110" check-smart-status does not use overrides when --device is used"

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
